### PR TITLE
moved email button on job listing.

### DIFF
--- a/client/components/Jobs/View.js
+++ b/client/components/Jobs/View.js
@@ -122,7 +122,7 @@ class JobView extends Component {
               {!job.contact_website &&
                 <div>
                   <br />
-                  <a href={`mailto:${job.contact_email}`} target="_blank"className="btn">
+                  <a href={`mailto:${job.contact_email}`} target="_blank" className="btn">
                     E-mail {job.contact_person}
                   </a>
                 </div>}

--- a/client/components/Jobs/View.js
+++ b/client/components/Jobs/View.js
@@ -121,11 +121,8 @@ class JobView extends Component {
                 </div>}
               {!job.contact_website &&
                 <div>
-                  <a
-                    href={`mailto:${job.contact_email}`}
-                    target="_blank"
-                    className="btn"
-                  >
+                  <br />
+                  <a href={`mailto:${job.contact_email}`} target="_blank"className="btn">
                     E-mail {job.contact_person}
                   </a>
                 </div>}


### PR DESCRIPTION
## Description
1. Name of Branch:
`wc-fix-job-email-button`

2. Tickets related to PR (with links):
[Bug: Email button overlaying text](https://github.com/egdelwonk/nashdev-jobs/issues/26)

3. Feature/Fix Description:
Added a `<br />` before the email button so that the button would not sit on top of the previous line. 

4. What architectural changes made:
Edited `client/components/Jobs/View.js`.

5. Repeating the issue:
When veiwing `/jobs/<job id>` and the posting has an `E-mail <contact person>` button, the button should not overlap the previous line.

## Testing
1. New Unit Tests:
No

2. All Tests Pass:
When running `docker-compose exec api npm run test` the following error occurs: `ERROR: No container found for api_1`.

## Documentation
1. Fully completed Documentation with signature:
N/A