### PR TITLE
Added characters 0-9 to company filter section.

### DIFF
--- a/client/components/Companies/List.js
+++ b/client/components/Companies/List.js
@@ -15,15 +15,25 @@ const sortByKeys = object => {
   return fromPairs(map(sortedKeys, key => [key, object[key]]));
 };
 
-const getAlphaList = () => {
-  return Array(26).fill().map((_, i) => {
+const getCharacterFilterList = () => {
+  const numbers = Array(10).fill().map((_, i) => {
+    const number = String.fromCharCode("0".charCodeAt(0) + i);
+    return (
+      <a href={`#${number}`} key={number} className="company-filter-item">
+        {number}
+      </a>
+    );
+  });
+  const letters =  Array(26).fill().map((_, i) => {
     const letter = String.fromCharCode("A".charCodeAt(0) + i);
     return (
-      <a href={`#${letter}`} key={letter} className="alphalist-item">
+      <a href={`#${letter}`} key={letter} className="company-filter-item">
         {letter}
       </a>
     );
   });
+  const allCharacters = letters.concat(numbers);
+  return allCharacters;
 };
 
 class CompanyList extends Component {
@@ -71,8 +81,8 @@ class CompanyList extends Component {
               Add Company
             </Link>
             <h4>Filter</h4>
-            <div className="alphalist-container">
-              {getAlphaList()}
+            <div className="company-filter-container">
+              {getCharacterFilterList()}
             </div>
           </aside>
         </div>

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -194,14 +194,14 @@ main {
   color: rgba(0, 0, 0, .3);
 }
 
-.alphalist-container {
+.company-filter-container {
   padding: 16px;
   border-bottom: 1px solid #e8e8e8;
   display: flex;
   flex-wrap: wrap;
 }
 
-.alphalist-item {
+.company-filter-item {
   font-size: 12px;
   margin: 16px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,16 +1068,9 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.6.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-runtime@^6.23.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -2132,16 +2125,9 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -4002,13 +3988,9 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-loader@0.5.4:
+json-loader@0.5.4, json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
-
-json-loader@^0.5.4:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -4575,17 +4557,13 @@ minimatch@~0.2.9:
     lru-cache "2"
     sigmund "~1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minimist@~1.1.0:
   version "1.1.3"
@@ -4887,7 +4865,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.1.0:
+object-assign@4.1.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
@@ -4895,7 +4873,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 


### PR DESCRIPTION
## Description
1. Name of Branch:
`wc-add-numbers-to-index`

2. Tickets related to PR (with links):
[Bug: Companies that start with a number do not have a quick-jump. . .](https://github.com/egdelwonk/nashdev-jobs/issues/36)

3. Feature/Fix Description:
Filter company by character list now includes the digits 0-9, as well as, A-Z.

4. What architectural changes made:
Changed `getAlphaList ` function to `getCharacterFilterList` in `client/components/Companies/List.js` file.
Changed `.alphalist-container` to `.company-filter-container` and changed `.alphalist-item` to `.company-filter-item` in `client/css/main.css` file.

5. Repeating the issue:
When viewing `/companies` page, the `Filters` section should list all letters A-Z and all digits 0-9.
When clicking on a letter or digit in `Filters`, if there is an existing company thats name begins with the character that was clicked the user will be redirected to that company's position on the page. 

## Testing
1. New Unit Tests:
No

2. All Tests Pass:
When running `docker-compose exec api npm run test` the following error occurs: `ERROR: No container found for api_1`.

## Documentation
1. Fully completed Documentation with signature:
N/A